### PR TITLE
Fixing bowls after order, spelling, change grammar

### DIFF
--- a/dialogue_manager.py
+++ b/dialogue_manager.py
@@ -7,6 +7,8 @@ from copy import deepcopy
 
 grammar_filename = 'ramen_grammar.fcfg'
 order = Order()
+termlimit = False
+item_rank = 0
 parser = nltk.parse.load_parser(grammar_filename)
 
 # for converting spelled numbers to arabic numerals
@@ -36,9 +38,7 @@ num_conversion_dict = {
 
 phrases_to_unify = ['with no', 'let me', 'as well as', 'in addition to',
             
-                    'lot of', 'lots of', 'on top of', 'large size', 'big size',
-                    'jumbo size', 'full size', 'regular size',
-                    'some more', 'small size', 'half size',
+                    'lot of', 'lots of', 'on top of', 'some more',
                     
                     'diet coca cola' , 'diet coke', 'diet cola', 'coca cola',
 
@@ -56,13 +56,24 @@ phrases_to_unify = ['with no', 'let me', 'as well as', 'in addition to',
 
                     'spring rolls', 'egg rolls', 'squid balls', 'chili oils', 'chili sauces',
                     'soy sauces', 'gyoza sauces',
-                    'sriracha sauces', 'fish cakes', 'bok choys', 'sea weeds', 'bean sprouts', ]
+                    'sriracha sauces', 'fish cakes', 'bok choys', 'sea weeds', 'bean sprouts',
+
+                    'not spicy', 'somewhat spicy', 'real spicy', 'very spicy', 'extremely spicy',
+
+                    'at all'
+                    ]
 
 
 phrases_to_eliminate = ['please', 'thanks', 'thank you', 'to order', 'to get', 'to have',
-                        'to buy', 'to eat', 'to add', 'extra', 'tea']
+                        'to buy', 'to eat', 'to add', 'extra', 'tea', 'size', 'sized','spring rolls',
+                        'egg rolls', 'squid balls', 'chili oils', 'chili sauces','soy sauces',
+                        'gyoza sauces','sriracha sauces', 'fish cakes', 'bok choys', 'sea weeds',
+                        'bean sprouts','at all']
 
-phrases_with_s = ["let's","plus", "as", "has", "lots", "yes", "glass"]
+phrases_to_eliminate = ['please', 'thanks', 'thank you', 'to order', 'to get', 'to have',
+                        'to buy', 'to eat', 'to add', 'extra', 'tea','size']
+
+phrases_with_s = ["let's","plus", "as", "has", "lots", "yes", "glass" ,"is"]
 
 def preprocess(sentence):
     s = sentence.lower()
@@ -87,6 +98,12 @@ def preprocess(sentence):
         i+=1
 
     for word in s:
+        # make sure that all the words are in the grammar; if not, ask to repeat
+        try:
+            parser.chart_parse([word])
+        except ValueError:
+            s = ''
+            return s
         #convert worded numbers to numerals
         if word in num_conversion_dict.keys():
             numeral = num_conversion_dict[word]
@@ -96,7 +113,7 @@ def preprocess(sentence):
         elif word == 'veggie' or word == 'veg':
             s[s.index(word)] = 'vegetable'
         # unify teas
-        elif word == 'jasmine_pearl' or word == 'pearl':
+        if word == 'jasmine_pearl' or word == 'pearl':
             s[s.index(word)] = 'jasmine'
         # unify sodas
         elif word == 'coke' or word == 'cola' or word == 'coca_cola':
@@ -107,20 +124,18 @@ def preprocess(sentence):
         elif word == 'minute_maid' or word == 'minute_made' or \
              word == 'minute_maid_lemonade' or word == 'minute_made_lemonade':
             s[s.index(word)] = 'lemonade'
-
-    # unify vegetables
-    for word in s:
-        if word == 'veggie' or word == 'veg':
-            s[s.index(word)] = 'vegetable'
-
-    # unify teas
-    for word in s:
-        if word == 'jasmine_pearl' or word == 'pearl':
-            s[s.index(word)] = 'jasmine'
-    # unify sodas
-
-    # unify lemonades
-            
+        # unify sizes:
+        elif word == 'small' or word == 'tiny' or word == 'baby':
+            s[s.index(word)] = 'half'
+        elif word == 'large' or word == 'big' or word == 'jumbo' or word =='whole' or word == 'regular':
+            s[s.index(word)] = 'full'
+        elif word == 'not_spicy':
+            s[s.index(word)] = 'mild'
+        elif word == 'somewhat_spicy':
+            s[s.index(word)] = 'medium'
+        elif word == 'very_spicy' or word == 'extremely_spicy' or word == 'real_spicy':
+            s[s.index(word)] = 'hot'
+           
     return s
 
 def parse_sentence(sentence):
@@ -128,18 +143,20 @@ def parse_sentence(sentence):
     return [tree for tree in parser.parse(processed)]
 
 def respond(sentence, parses):
+    global termlimit, item_rank
     if len(parses) == 0:
         return "I'm sorry; I don't know what that means."
-    
     #user response to "would you like anything else?"
     elif parses[0].leaves() == ['yes']:
         return "What else can I get for you?"
     elif parses[0].leaves() == ['no']:
+        termlimit = True
         # check ramen bowls for missing information here...
         for item in order.items:
+            item_rank = order.items.index(item)
             if isinstance(item, RamenBowl):
                 if item.broth == None:
-                    response = "What broth would you like for your ramen?\n'shio', 'shoyu', 'miso', 'tonkatsu', 'vegan'"
+                    response = "What broth would you like for your ramen?\n'shio', 'shoyu', 'miso', 'tontaksu', 'vegan'"
                     return response
                 if item.spiciness == None:
                     response = "How spicy would you like your ramen?\n mild, medium, or hot"
@@ -150,7 +167,8 @@ def respond(sentence, parses):
                 if item.toppings == None:
                     response = "Would you like any toppings in your ramen?\nfishcake, naruto, mushroom, bean sprouts, kimchi, bok choy, seaweed (nori)"
                     return response                
-        return "Your total is " + str(order.price()) + "."
+        return "Your total is $" + str(order.price()) + ".00"
+        order.reset()
     #cyute
     elif parses[0].leaves() == ['summon', 'mama']:
         try:
@@ -168,93 +186,120 @@ def respond(sentence, parses):
         
         # Get the OIs in the parse.
         order_items = get_OIs(parse)
-        # Iterate through the OIs and add the foods they mention to the
-        # order.
-        for item in order_items:
-            # Figure out what kind of item the user requested by looking
-            # for keywords.
-            leaves = item.leaves()
-            word_set = set(leaves)
-            item_type = 'none'
-            item_word = ''
-            multiple = 1
-            n = 1
-            if len(word_set & set(num_conversion_dict.values())) > 0:
-                multiple = int(list(set(word_set) & \
-                                set(num_conversion_dict.values()))[0])
-            #broths (and ramen for now)
-            if len(word_set & broths) > 0\
-               or len(word_set & proteins) > 0\
-                or len(word_set & cont_nouns) > 0:
-                        item_type = 'ramen_bowl'
-            #apps
-            elif len(word_set & set(apps.keys())) > 0:
-                item_type = 'app'
-                item_word = list(word_set & set(apps.keys()))[0]
 
-            #drinks
-            elif len(word_set & set(drinks.keys())) > 0:
-                item_type = 'drink'
-                item_word = list(word_set & set(drinks.keys()))[0]
+        # if they're not done ordering, add new items
+        if termlimit == False:
+            # Iterate through the OIs and add the foods they mention to the
+            # order.
+            for item in order_items:
+                # Figure out what kind of item the user requested by looking
+                # for keywords.
+                leaves = item.leaves()
+                word_set = set(leaves)
+                item_type = 'none'
+                item_word = ''
+                multiple = 1
+                n = 1
+                if len(word_set & set(num_conversion_dict.values())) > 0:
+                    multiple = int(list(set(word_set) & \
+                                    set(num_conversion_dict.values()))[0])
+                #broths (and ramen for now)
+                if len(word_set & broths) > 0\
+                   or len(word_set & proteins) > 0\
+                    or len(word_set & cont_nouns) > 0:
+                            item_type = 'ramen_bowl'
+                #apps
+                elif len(word_set & set(apps.keys())) > 0:
+                    item_type = 'app'
+                    item_word = list(word_set & set(apps.keys()))[0]
 
-            elif len(word_set & set(sauces.keys())):
-                item_type = 'sauce'
-                item_word = list(word_set & set(sauces.keys()))[0]
-                
-            # If the user wants a ramen bowl...
-            if item_type == 'ramen_bowl':
-                new_ramen = RamenBowl()
-                # Check for toppings in the leaves of the tree.
+                #drinks
+                elif len(word_set & set(drinks.keys())) > 0:
+                    item_type = 'drink'
+                    item_word = list(word_set & set(drinks.keys()))[0]
+
+                elif len(word_set & set(sauces.keys())):
+                    item_type = 'sauce'
+                    item_word = list(word_set & set(sauces.keys()))[0]
+                    
+                # If the user wants a ramen bowl...
+                if item_type == 'ramen_bowl':
+                    new_ramen = RamenBowl()
+                    # Check for toppings in the leaves of the tree.
+                    for leaf in leaves:
+                        if leaf in toppings:
+                            new_ramen.add_toppings(leaf)
+                        elif leaf in broths:
+                            new_ramen.update_broth(leaf)
+                        elif leaf in sizes:
+                            new_ramen.update_size(leaf)
+                        elif leaf in proteins:
+                            new_ramen.update_protein(leaf)
+                            
+                    if multiple == 1:
+                        order.add_item(deepcopy(new_ramen))
+                        response += "  I've added a ramen bowl to your order."
+                    else:
+                        while n <= multiple:
+                            order.add_item(deepcopy(new_ramen))
+                            n+=1
+                        response += "  I've added " + str(multiple) + " ramen bowls to your order."
+                    
+                # If the user mentioned an app...
+                elif item_type == 'app':
+                    new_app = App(item_word)
+                    if multiple == 1:
+                        order.add_item(deepcopy(new_app))
+                        response += "  I've added a " + item_word + " to your order."
+                    else:
+                        while n <= multiple:
+                            order.add_item(deepcopy(new_app))
+                            n+=1
+                        response += "  I've added " + str(multiple)+ " " + item_word + "s " + " to your order."
+                    
+                # If the user mentioned a drink...
+                elif item_type == 'drink':
+                    new_drink = Drink(item_word)
+                    if multiple == 1:
+                        order.add_item(deepcopy(new_drink))
+                        response += "  I've added a " + item_word + " to your order."
+                    else:
+                        while n <= multiple:
+                            order.add_item(deepcopy(new_drink))
+                            n+=1                    
+                        response += "  I've added " + str(multiple) + " "+ item_word + "s " + " to your order."
+
+                # If the user mentioned a sauce...
+                elif item_type == 'sauce':
+                    new_sauce = Sauce(item_word)
+                    if multiple == 1:
+                        order.add_item(deepcopy(new_sauce))
+                        response += "  I've added a " + item_word + " to your order."
+                    else:
+                        while n <= multiple:
+                            order.add_item(deepcopy(new_sauce))
+                            n+=1
+                        response += "  I've added " + str(multiple) + " " + item_word + "s " + " to your order."
+
+            response += "  Would you like anything else?"
+            return response
+        else:
+            for item in order_items:
+                leaves = item.leaves()
                 for leaf in leaves:
                     if leaf in toppings:
-                        new_ramen.add_toppings(leaf)
-                if multiple == 1:
-                    order.add_item(deepcopy(new_ramen))
-                    response += "  I've added a ramen bowl to your order."
-                else:
-                    while n <= multiple:
-                        order.add_item(deepcopy(new_ramen))
-                        n+=1
-                    response += "  I've added " + str(multiple) + " ramen bowls to your order."
-                
-            # If the user mentioned an app...
-            elif item_type == 'app':
-                new_app = App(item_word)
-                if multiple == 1:
-                    order.add_item(deepcopy(new_app))
-                    response += "  I've added a " + item_word + " to your order."
-                else:
-                    while n <= multiple:
-                        order.add_item(deepcopy(new_app))
-                        n+=1
-                    response += "  I've added " + str(multiple)+ " " + item_word + "s " + " to your order."
-                
-            # If the user mentioned a drink...
-            elif item_type == 'drink':
-                new_drink = Drink(item_word)
-                if multiple == 1:
-                    order.add_item(deepcopy(new_drink))
-                    response += "  I've added a " + item_word + " to your order."
-                else:
-                    while n <= multiple:
-                        order.add_item(deepcopy(new_drink))
-                        n+=1                    
-                    response += "  I've added " + str(multiple) + " "+ item_word + "s " + " to your order."
-
-            # If the user mentioned a sauce...
-            elif item_type == 'sauce':
-                new_sauce = Sauce(item_word)
-                if multiple == 1:
-                    order.add_item(deepcopy(new_sauce))
-                    response += "  I've added a " + item_word + " to your order."
-                else:
-                    while n <= multiple:
-                        order.add_item(deepcopy(new_sauce))
-                        n+=1
-                    response += "  I've added " + str(multiple) + " " + item_word + "s " + " to your order."
-
-        response += "  Would you like anything else?"
-        return response
+                        order.items[item_rank].add_toppings(leaf)                    
+                    elif leaf in spiciness:
+                        order.items[item_rank].update_spice(leaf)
+                    elif leaf in broths:
+                        order.items[item_rank].update_broth(leaf)
+                    elif leaf in sizes:
+                        order.items[item_rank].update_size(leaf)
+                    elif leaf in proteins:
+                        order.items[item_rank].update_protein(leaf)
+                        
+    respond('no',parse_sentence('no'))
+                    
 
 def get_OIs(parse):
     """Return the subtrees of the parse that are OIs."""

--- a/kitchen.py
+++ b/kitchen.py
@@ -12,7 +12,18 @@ class RamenBowl:
         self.protein = protein
         self.toppings = []
         self.sauces = []
-    
+    def update_broth(self, broth_new):
+        if broth_new in broths:
+            self.broth = broth_new
+    def update_protein(self,new_protein):
+        if new_protein in proteins:
+            self.protein = new_protein
+    def update_size(self, size_to_add):
+        if size_to_add in sizes:
+            self.size = size_to_add
+    def update_spice(self, spice_to_add):
+        if spice_to_add in spiciness:
+            self.spiciness = spice_to_add
     def add_toppings(self, toppings_to_add):
         if isinstance(toppings_to_add, list):
             for topping in toppings_to_add:
@@ -35,13 +46,18 @@ class RamenBowl:
         return price
     
     def __str__(self):
-        string = self.size
+        string = ''
+        if self.spiciness is None:
+            string += 'NA '
+        else:
+            string += self.spiciness + ' '
+        string += self.size
         if self.broth is None:
-            string += ' ramen'
+            string += ' NA'
         else:
             string += ' ' + self.broth
         if self.protein is None:
-            string += ' (choose protein)'
+            string += ' NA'
         else:
             string += ' ' + self.protein
         if len(self.toppings) > 0:
@@ -115,3 +131,6 @@ class Order:
         if len(self.items) > 0:
             string = '\n'.join(str(item) for item in self.items)
         return string
+    
+    def reset(self):
+        items = []        

--- a/menu.py
+++ b/menu.py
@@ -1,4 +1,4 @@
-broths = {'shio', 'shoyu', 'miso', 'tonkatsu', 'vegan'}
+broths = {'shio', 'shoyu', 'miso', 'tontaksu', 'vegan'}
 ramen = {'ramen'}
 cont_nouns = {'bowl'}
 spiciness = {"mild", "medium", "hot"}
@@ -27,7 +27,6 @@ drinks = {'coke': {'price': 1.5},
           'sencha': {'price': 2},
           'jasmine': {'price': 2},
           'bancha': {'price': 2},
-          'water' : {'price': 0}}
-    
+          'water' : {'price': 2}}    
 sizes = {'half': {'price': 9},
          'full': {'price':12}}

--- a/order_food.py
+++ b/order_food.py
@@ -1,6 +1,5 @@
 from tkinter import *
 from dialogue_manager import parse_sentence, respond, order
-#import PIL
 log_file_name = 'testing_log.txt'
 
 class App(Frame):
@@ -62,7 +61,7 @@ class App(Frame):
         print()
 
 root = Tk()
-cuter = font.Font(family="Kristen ITC",size=12,weight="normal")
+cuter = font.Font(family="Comic Sans MS",size=12,weight="normal")
 root.option_add("*Font", cuter)
 root.columnconfigure(index = 0, weight = 1)
 app = App(master = root)

--- a/ramen_grammar.fcfg
+++ b/ramen_grammar.fcfg
@@ -23,6 +23,7 @@ OI -> NP[NTYPE=app]
 OI -> NP[NTYPE=broth]
 OI -> NP[NTYPE=sauce]
 OI -> NP[NTYPE=Cnouns]
+OI -> JJ
 
 #adjective recursion
 JJ[JTYPE=?t] -> JJ[JTYPE=?t] JJ[JTYPE=?t]
@@ -55,8 +56,8 @@ NP[NTYPE=?t, CONT=YES]-> N[NTYPE=broth] N CJ N[NTYPE=protein]
 NP[NTYPE=?t, CONT=YES]-> JJ N[NTYPE=broth] N CJ N[NTYPE=protein]
 
 #recursive toppings
-N[NTYPE=?t]-> N[NTYPE=protein] CJ N[NTYPE=protein]
-N[NTYPE=?t]-> N[NTYPE=toppings] CJ N[NTYPE=toppings]
+N[NTYPE=?t, +CONJ]-> N[NTYPE=protein, -CONJ] CJ N[NTYPE=protein]
+N[NTYPE=?t, +CONJ]-> N[NTYPE=toppings, -CONJ] CJ N[NTYPE=toppings]
 
 #ex. "a miso ramen with beef and egg"
 NP[NTYPE=?t, CONT=YES]-> Det N[NTYPE=broth] N CJ N[NTYPE=protein] CJ N[NTYPE=toppings]
@@ -131,13 +132,15 @@ P -> "with" |"aboard" |"amid" | "among" | "on_top_of" | "inside" | "plus"
 
 Pronoun -> "it" | "them"
 
-JJ[JTYPE=size]-> "large" | "large_size" | "whole" | "whole_size" | "big" | "big_size" | "jumbo" | "jumbo_size" | "full" | "full_size" | "regular" | "regular_size" | "half" | "half_size" | "small" | "small_size" | "really"
+JJ[JTYPE=size]-> "half" | "full"
 
 JJ[JTYPE=qty]-> "extra" | "lot_of" | "lots_of" | "more" | "some" | "some_more" | "another"
 
-JJ[JTYPE=broth]-> "shio" | "miso" | "shoyu" | "tamkatsu" | "vegan" 
+JJ[JTYPE=broth]-> "shio" | "miso" | "shoyu" | "tontaksu" | "vegan" 
 
-JJ[JTYPE=spice] -> "mild" | "medium" | "hot" | "spicy" 
+JJ[JTYPE=spice] -> "mild" | "medium" | "hot"
+
+JJ[JTYPE=protein] ->"beef"| "tofu" | "pork" | "chicken" | "vegetable" | "veggie" | "veg" 
 
 M -> "would" | "will" | "could" | "can" | "do" | "does" | "should" | "shall" | "may" | "might"
 
@@ -154,42 +157,25 @@ N[NTYPE=Cnouns, CONT=YES,+MACRO] -> "half" | "full" | "side" | "bowl" | "plate" 
 N[NTYPE=?t, CONT=NO, +MACRO] -> "ramen" | "ramens"
 
 # broth nouns, singular
-N[NTYPE=broth, CONT=NO,+MACRO]->"shio" | "miso" | "shoyu" | "tonkatsu" | "vegan" 
+N[NTYPE=broth, CONT=NO,+MACRO]->"shio" | "miso" | "shoyu" | "tontaksu" | "vegan" 
 
 # protein nouns, singualr
 N[NTYPE=protein, CONT=NO,-MACRO]->"beef"| "tofu" | "pork" | "chicken" | "vegetable" | "veggie" | "veg" 
 
-# protein nouns, plural
-N[NTYPE=protein, CONT=NO,-MACRO]->"beefs"| "tofus" | "porks" | "chickens" | "vegetables" | "veggies" | "vegs"
-
 # toppings nouns, singular
 N[NTYPE=toppings, CONT=NO,-MACRO]-> "egg" | "tamagoyaki" | "fishcake" | "fish_cake" | "naruto" | "mushroom" | "bean_sprout" | "sprout" |  "kimchi" | "bok_choy" | "seaweed" | "sea_weed" | "nori" 
-
-# toppings nouns, plural
-N[NTYPE=toppings, CONT=NO,-MACRO]-> "eggs" | "tamagoyakis" | "fishcakes" | "fish_cakes" | "fish-cakes" | "narutos" | "mushrooms" | "bean_sprouts" | "sprouts" |  "kimchis" | "bok_choys" | "seaweeds" | "sea_weeds" | "noris" 
 
 # sauce nouns, singular
 N[NTYPE=sauce, CONT=NO,-MACRO]->"chili_oil" | "sriracha" | "gyoza_sauce" | "gyoza" | "sriracha_sauce" | "chili_sauce" | "soy_sauce" | "soy"
 
-# sauce nouns, plural
-N[NTYPE=sauce, CONT=NO,-MACRO]->"chili_oils" | "srirachas" | "gyoza_sauces" | "gyozas" | "sriracha_sauces" | "chili_sauces" | "soy_sauces" | "soys"
-
 # app nouns, singular
 N[NTYPE=app, CONT=NO,-MACRO]-> "gyoza" | "dumpling" |"edamame" | "spring_roll" | "egg_roll" | "squid_ball" | "takoyaki" 
 
-# app nouns, plural
-N[NTYPE=app, CONT=NO,-MACRO]-> "gyozas" | "dumplings" |"edamames" | "spring_rolls" | "egg_rolls" | "squid_balls" | "takoyakis" 
-
 # drink nouns, singular
-N[NTYPE=drink, CONT=NO,-MACRO]-> "coke" | "cola" | "coca-cola" | "diet-coke" | "diet_coca-cola" | "coca_cola" | "diet_coca_cola" | "sprite" |  "minute-maid_lemonade" | "minute_maid_lemonade" | "minute_maid" | "minute-maid" | "lemonade" | "sencha_tea" | "jasmine_tea" | "jasmine_pearl_tea" | "pearl_tea" | "bancha_tea" | "sencha" | "jasmine" | "pearl" | "bancha" | "water"
-
-#drink nouns, plural
-N[NTYPE=drink,-MACRO]-> "cokes" | "colas" | "coca-colas" | "diet-cokes" | "diet_coca-colas" | "coca_colas" | "diet_coca_colas" | "sprites" |  "minute-maid_lemonades" | "minute_maid_lemonades" | "minute_maids" | "minute-maids" | "lemonades" | "sencha_teas" | "jasmine_teas" | "jasmine_pearl_teas" | "pearl_teas" | "bancha_teas" | "senchas" | "jasmines" | "pearls" | "banchas" | "waters" 
+N[NTYPE=drink, CONT=NO,-MACRO]-> "coke" | "diet_coke" | "sprite" |  "lemonade" | "sencha" | "jasmine" | "bancha" | "water"
 
 #user responses
 R -> "yes" | "no"
 
 #easter egg
-M -> "summon" | "mama"
-M -> "Who's" | "who is" | "mama" 
-
+M -> "summon" | "mama" | "bloody" | "Who's" | "who is"


### PR DESCRIPTION
The bowls can now be altered when the user says 'no' to continuing to order.  There is one bug in that after every update, you then have to type 'no' again (working on a fix).  Spelling of one broth was changed to reflect the spell-checked menu Joselyn uploaded (across files), and grammar was updated to include adjective only order item for use after the bowls have been order (eg.  your response can be 'mild' to the question, 'how spicy did you want that?'), conjoined NPs were added to accommodate compelx PPs, and words that would be preprocessed were deleted for ease of reading the fcfg